### PR TITLE
quantize down to 1e3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,6 +254,7 @@ Tilesplash.prototype.layer = function(name, ___){
           done(err);
         } else {
           var topology = topojson.topology(geojsonLayers, {
+            'quantization': 1e3,
             'property-transform': function(properties, key, value){
               properties[key] = value;
               return true;


### PR DESCRIPTION
Picks up topojson conversion speed by ~50% and incidentally simplifies _some_ geometries [without adversely affecting rendering](http://stackoverflow.com/a/18921214). Note this quantization difference will have no effect on - say - hexagons; it's meant to help with complex geometries:

![So fresh and so clean clean](https://cloud.githubusercontent.com/assets/735463/5890015/022d7942-a412-11e4-97d1-81dd1b136321.png)




