### PR TITLE
Add instrumentation to TileSplash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+.DS_Store

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ function setStatementTimeout(client) {
   return new Promise(function(resolve, reject){
     var statementTimeout = parseInt(process.env.TILESPLASH_STATEMENT_TIMEOUT) || 0;
     if (statementTimeout && statementTimeout > 0) {
-      client.query('SET statement_timeout='+statementTimeout, [], function(err, result){
+      client.query('SET statement_timeout='+statementTimeout, [], function(err){
         if (err) {
           reject(err);
         } else {
@@ -84,7 +84,20 @@ var pgMiddleware = function(_dbOptions){
   };
 };
 
-var Tilesplash = function(dbOptions, cacheType, cacheOptions){
+/*
+Tilesplash
+@constructor
+
+- dbOptions : options passed to the postgres database, required
+- cacheType : how to cache tiles, defaults to 'memory', optional
+- cacheOptions : options to pass to the caching library <https://www.npmjs.com/package/caching>, optional
+- instrument : probes to instrument various parts of the query cycle, optional. Instrumentation points:
+  - parseSql: time it takes to parse sql templates into sql strings
+  - toGeoJson: the time it takes to run the sql and translate it to geojson
+  - runQuery: the time it takes to run a query  (I think)
+  - gotTile: the round-trip time to get a tile (I think)
+ */
+var Tilesplash = function(dbOptions, cacheType, cacheOptions, instrument){
   this.projection = new SphericalMercator({
     size: 256
   });
@@ -93,7 +106,7 @@ var Tilesplash = function(dbOptions, cacheType, cacheOptions){
   this.dbCacheKey = JSON.stringify(dbOptions);
 
   this.server = express();
-
+  this.instrument = instrument || {};
   var timeout = parseInt(process.env.TILESPLASH_REQUEST_TIMEOUT) || 0;
 
   if (timeout) {
@@ -138,7 +151,7 @@ Tilesplash.prototype.defaultCacheKeyGenerator = function(tile){
 
 Tilesplash.prototype.cache = function(cacheKeyGenerator, ttl){
   var self = this;
-  if (typeof cacheKeyGenerator == 'number') {
+  if (typeof cacheKeyGenerator === 'number') {
     ttl = cacheKeyGenerator;
     cacheKeyGenerator = undefined;
   }
@@ -148,7 +161,7 @@ Tilesplash.prototype.cache = function(cacheKeyGenerator, ttl){
   this.defaultTtl = ttl;
 };
 
-function stringifyTopojson(layers, tile){
+function stringifyTopojson(layers){
   layers = clone(layers);
   return topojson.topology(layers, {
     'property-transform': function(properties, key, value){
@@ -158,7 +171,7 @@ function stringifyTopojson(layers, tile){
   });
 }
 
-Tilesplash.prototype.layer = function(name, ___){
+Tilesplash.prototype.layer = function(name){
   var callbacks = Array.prototype.slice.call(arguments);
   callbacks.shift();
   var tileRenderer = callbacks.pop();
@@ -200,7 +213,7 @@ Tilesplash.prototype.layer = function(name, ___){
       throwError( (msg instanceof Error) ? msg : new Error(msg) );
     };
 
-    if (req.params.ext != 'topojson') {
+    if (req.params.ext !== 'topojson') {
       render.error('unsupported extension '+req.params.ext);
       return;
     }
@@ -214,24 +227,47 @@ Tilesplash.prototype.layer = function(name, ___){
     tile.z = req.params.z*1;
 
     tile.bounds = self.projection.bbox(req.params.x, req.params.y, req.params.z, false, '900913');
-    tile.bbox = 'ST_SetSRID(ST_MakeBox2D(ST_MakePoint('+tile.bounds[0]+', '+tile.bounds[1]+'), ST_MakePoint('+tile.bounds[2]+', '+tile.bounds[3]+')), 3857)';
+    tile.bbox = [
+      'ST_SetSRID(',
+        'ST_MakeBox2D(',
+          'ST_MakePoint(', tile.bounds[0], ', ', tile.bounds[1], '), ',
+          'ST_MakePoint(', tile.bounds[2], ', ', tile.bounds[3], ')',
+        '), ',
+        '3857',
+      ')'
+    ].join('');
     tile.bbox_4326 = 'ST_Transform('+tile.bbox+', 4326)';
     tile.geom_hash = 'Substr(MD5(ST_AsBinary(the_geom)), 1, 10)';
 
     self.log('Rendering tile '+tile.layer+'/'+tile.z+'/'+tile.x+'/'+tile.y, 'debug');
 
+    function startTrace() {
+      var start = process.hrtime();
+      return function endTrace() {
+        var diff = process.hrtime(start);
+
+        return (diff[0] * 1e9 + diff[1])/1000;
+      };
+    }
+
+
     var parseSql = function(sql, done){
-      if (typeof sql == 'number') {
+      var trace = startTrace(),
+          instrument = self.instrument.parseSql || function() {};
+
+      if (typeof sql === 'number') {
+        instrument(trace());
         done(null, sql);
         return;
       }
-      if (typeof sql == 'object') {
+      if (typeof sql === 'object') {
         if (Array.isArray(sql)) {
           async.map(sql, function(item, next){
             parseSql(item, function(err, out){
               next(err, out);
             });
           }, function(err, results){
+            instrument(trace());
             done(err, results);
           });
           return;
@@ -246,17 +282,18 @@ Tilesplash.prototype.layer = function(name, ___){
             keys.forEach(function(d, i){
               output[d] = results[i];
             });
+
+            instrument(trace());
             done(err, output);
           });
           return;
         }
       }
-      if (typeof sql != 'string') {
+      if (typeof sql !== 'string') {
         done(['Trying to parse non-string SQL', sql]);
         return;
       }
-      var templatePattern = /\!([0-9a-zA-Z_\-]+)\!/g;
-      var templateVariables = {};
+      var templatePattern = /!([0-9a-zA-Z_\-]+)!/g;
 
       sql = sql.replace(templatePattern, function(match){
         match = match.substr(1, match.length-2);
@@ -266,25 +303,33 @@ Tilesplash.prototype.layer = function(name, ___){
     };
 
     var sqlToGeojson = function(sql, done){
+      var instrument = self.instrument.toGeoJson || function() {},
+          trace = startTrace();
+
       if (sql === false || sql === null) {
+        instrument(trace());
         done(null, {});
         return;
       }
       parseSql(sql, function(parsingError, fullsql){
         if (parsingError) {
+          instrument(trace());
           done(parsingError);
           return;
         }
         var args = [];
-        if (typeof fullsql == 'object' && Array.isArray(fullsql)) {
+        if (typeof fullsql === 'object' && Array.isArray(fullsql)) {
           args = fullsql;
           fullsql = args.shift();
         }
         self.log('Running Query', 'debug');
         self.log('  SQL: '+fullsql, 'debug');
         self.log('  Arguments: '+JSON.stringify(args), 'debug');
+
+
         req.db.query(fullsql, args, function(sqlError, result){
           if (sqlError) {
+            instrument(trace());
             done([sqlError, fullsql, args]);
           } else {
             var geojson = {
@@ -294,7 +339,7 @@ Tilesplash.prototype.layer = function(name, ___){
             result.rows.forEach(function(row){
               var properties = {};
               for (var attribute in row) {
-                if (attribute != 'the_geom_geojson') {
+                if (attribute !== 'the_geom_geojson') {
                   properties[attribute] = row[attribute];
                 }
               }
@@ -305,6 +350,7 @@ Tilesplash.prototype.layer = function(name, ___){
               });
             });
 
+            instrument(trace());
             done(null, geojson);
           }
         });
@@ -313,11 +359,11 @@ Tilesplash.prototype.layer = function(name, ___){
 
     var tileContext = {
       cache: function(cacheKeyGenerator, ttl){
-        if (typeof cacheKeyGenerator == 'number') {
+        if (typeof cacheKeyGenerator === 'number') {
           ttl = cacheKeyGenerator;
           cacheKeyGenerator = undefined;
         }
-        if (typeof cacheKeyGenerator == 'function') {
+        if (typeof cacheKeyGenerator === 'function') {
           this._cacher = cacheKeyGenerator;
         }
         this._ttl = ttl;
@@ -325,12 +371,16 @@ Tilesplash.prototype.layer = function(name, ___){
     };
 
     var runQuery = function(structuredSql, done){
+      var instrument = self.instrument.runQuery || function() {},
+          trace = startTrace();
+
       if (structuredSql === false || structuredSql === null) {
+        instrument(trace());
         done(null, {});
         return;
       }
 
-      if (typeof structuredSql != 'object' || Array.isArray(structuredSql)) {
+      if (typeof structuredSql !== 'object' || Array.isArray(structuredSql)) {
         structuredSql = {vectile: structuredSql};
       }
 
@@ -345,6 +395,7 @@ Tilesplash.prototype.layer = function(name, ___){
           }
         });
       }, function(err){
+        instrument(trace());
         if (err) {
           done(err);
         } else {
@@ -354,8 +405,12 @@ Tilesplash.prototype.layer = function(name, ___){
     };
 
     var gotTile = function(tileOutput){
+      var instrument = self.instrument.gotTile || function() {},
+          trace = startTrace();
+
       parseSql(tileOutput, function(parsingError, structuredSql){
         if (parsingError) {
+          instrument(trace());
           render.error(['SQL Parsing Error', parsingError]);
           return;
         }
@@ -365,11 +420,13 @@ Tilesplash.prototype.layer = function(name, ___){
           var cacheKey = cacher(tile);
           var ttl = tileContext._ttl || self.defaultTtl || 3600000;
           self._cache(cacheKey, ttl, function(done){
+            instrument(trace());
             self.log('cache miss', 'debug');
             runQuery(structuredSql, function(queryError, layers){
               done(queryError, layers);
             });
           }, function(layerError, layers){
+            instrument(trace());
             if (layerError) {
               render.error(['layer error', layerError]);
             } else {
@@ -378,6 +435,7 @@ Tilesplash.prototype.layer = function(name, ___){
           });
         } else {
           runQuery(structuredSql, function(queryError, layers){
+            instrument(trace());
             if (queryError) {
               render.error(['error running query', queryError]);
             } else {
@@ -388,11 +446,8 @@ Tilesplash.prototype.layer = function(name, ___){
       });
     };
 
-    var outputData;
-
     async.eachSeries(callbacks, function(middleware, next){
-      middleware(req, res, tile, function(err, data){
-        outputData = data;
+      middleware(req, res, tile, function(err){
         next(err);
       });
     }, function(err){


### PR DESCRIPTION
Adds instrumentation features to track how long it takes for certain actions in tilesplash to complete.

+ parseSql: time it takes to parse sql templates into sql strings
+ toGeoJson: the time it takes to run the sql and translate it to geojson
+ runQuery: the time it takes to run a query  (I think)
+ gotTile: the round-trip time to get a tile (I think)

Also cleaned up the code so it would pass a reasonable level of scrutiny by eslint.