### PR TITLE
`render.empty()` should return real empty tile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -217,9 +217,7 @@ Tilesplash.prototype.layer = function(name){
         }
       });
     };
-    render.empty = function(){
-      render.raw({});
-    };
+
     render.error = function(msg){
       render.raw(500);
       throwError( (msg instanceof Error) ? msg : new Error(msg) );
@@ -237,6 +235,10 @@ Tilesplash.prototype.layer = function(name){
     tile.x = req.params.x*1;
     tile.y = req.params.y*1;
     tile.z = req.params.z*1;
+
+    render.empty = function(){
+      render.raw(stringify([], tile));
+    };
 
     tile.bounds = self.projection.bbox(req.params.x, req.params.y, req.params.z, false, '900913');
     tile.bbox = [


### PR DESCRIPTION
The original `render.empty()` returns an empty object, not a valid tile (at least for protobuf). This fix will ensure the function returns a valid empty tile with given tile parameters.