### PR TITLE
Use HTTP status 204 for empty tiles

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ var pgMiddleware = function(_dbOptions){
       }, 5000);
 
       var pool = new pg.Pool(dbOptions);
-      
+
       pool.connect(function(err, client, done){
         if (poolTimedOut) {
           done();
@@ -431,6 +431,12 @@ Tilesplash.prototype.layer = function(name){
       });
     };
 
+    var hasFeatures = function(layers) {
+      for (var layerName in layers)
+        if (layers[layerName].features.length) return true;
+      return false;
+    };
+
     var gotTile = function(tileOutput){
       var instrument = self.instrument.gotTile || function() {},
           trace = startTrace();
@@ -463,6 +469,8 @@ Tilesplash.prototype.layer = function(name){
             instrument(trace());
             if (layerError) {
               render.error(['layer error', layerError]);
+            } else if (!hasFeatures(layers)) {
+              res.sendStatus(204);
             } else {
               res.send(stringify(layers, tile, mvtOptions));
             }
@@ -472,6 +480,8 @@ Tilesplash.prototype.layer = function(name){
             instrument(trace());
             if (queryError) {
               render.error(['error running query', queryError]);
+            } else if (!hasFeatures(layers)) {
+              res.sendStatus(204);
             } else {
               res.send(stringify(layers, tile, mvtOptions));
             }


### PR DESCRIPTION
Mapbox GL JS throws `Error: http status 200 returned without content` when it encounters a tile with no features. The Mapbox team recommends using HTTP status code 204 to indicate the absence of tile data. (See mapbox/mapbox-gl-js#1800.)